### PR TITLE
Make monkeypatched #exception cause fewer exceptions

### DIFF
--- a/lib/pry-exception_explorer/core_ext.rb
+++ b/lib/pry-exception_explorer/core_ext.rb
@@ -31,7 +31,9 @@ class Exception
   alias_method :old_exception, :exception
 
   def exception(*args, &block)
-    if PryExceptionExplorer.enabled? &&
+    if defined?(PryExceptionExplorer) &&
+        PryExceptionExplorer.respond_to?(:enabled?) &&
+        PryExceptionExplorer.enabled? &&
         PryExceptionExplorer.should_intercept_exception?(binding.of_caller(1), self) &&
         !caller.any? { |t| t.include?("raise") } && !exception_call_stack
 


### PR DESCRIPTION
The load sequence is such that  `pry-exception_explorer.rb` pulls in `pry-exception_explorer/core_extensions.rb` before `PryExceptionExplorer.enabled?` is defined, so it has the potential to cause infinite recursion.

This patch makes it guarded against that, though what also works is moving the `require 'pry-exception_explorer/core_extensions'` down below the `module PryExceptionExplorer` definition.
